### PR TITLE
Upgrade to Restify 5

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,13 +70,23 @@ function startAPI(){
 
 	let server = restify.createServer(serverOptions);
 
-	server.use(restify.acceptParser(server.acceptable));
-	server.use(restify.dateParser());
-	server.use(restify.queryParser());
-	server.use(restify.gzipResponse());
-	server.use(restify.bodyParser());
-	server.use(restify.CORS());
-	server.use(restify.throttle({
+	// CORS Setup
+	const corsMiddleware = require('restify-cors-middleware');
+
+	const cors = corsMiddleware({
+		origins        : ['*'],
+		allowHeaders   : ['Authorization'],
+	});
+
+	server.pre(cors.preflight);
+	server.use(cors.actual);
+
+	server.use(restify.plugins.acceptParser(server.acceptable));
+	server.use(restify.plugins.dateParser());
+	server.use(restify.plugins.queryParser());
+	server.use(restify.plugins.gzipResponse());
+	server.use(restify.plugins.bodyParser());
+	server.use(restify.plugins.throttle({
 		burst: 100,
 		rate: 50,
 		ip: true,

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "jsonwebtoken": "^7.4.1",
     "moment": "^2.18.1",
     "mongoose": "^4.10.0",
-    "restify": "^4.3.0",
+    "restify": "^5.2.0",
+    "restify-cors-middleware": "^1.0.1",
     "underscore": "^1.8.3"
   }
 }


### PR DESCRIPTION
Restify 5 has been released.  Updated from 4 to 5.  Really this is for
an easier to use static server plugin that will be used in an upcoming
PR.