### PR TITLE
Slug support and a easier way to handle pages

### DIFF
--- a/index.js
+++ b/index.js
@@ -111,7 +111,8 @@ function startAPI(){
 		next();
 	});
 
-	Morty.middleware = require(Morty.path.root + '/middleware');
+	Morty.middleware = require(`${Morty.path.root}/middleware`);
+	Morty.utility = require(`${Morty.path.lib}/utility`);
 
 	attachToNamespace('models')
 	.then(_.partial(initializeRoutes, server))

--- a/lib/utility.js
+++ b/lib/utility.js
@@ -1,0 +1,8 @@
+/**
+ * Returns whether the provided input is an alphanumeric 24 length string
+ * @param  {String}  string Input to check
+ * @return {Boolean}        Whether input is a valid object id
+ */
+exports.isValidObjectId = (string) => {
+	return _.isString(string) && /^[a-fA-F0-9]{24}$/.test(string);
+};

--- a/models/post.js
+++ b/models/post.js
@@ -16,6 +16,13 @@ var schema = new require('mongoose').Schema({
 	content : {
 		type : String
 	},
+	slug : {
+		type    : String,
+		unique  : true,
+		default : null,
+		trim    : true,
+		sparse  : true
+	},
 	categories : [
 		{
 			type : String

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "serve": "cross-env NODE_ENV=production node index.js",
     "build": "npm run build:client && npm run build:server",
     "build:client": "rimraf react/buildClient && cross-env NODE_ENV=production webpack --progress -p --config react/client.prod.js",
+	"build:client:dev": "rimraf react/buildClient && cross-env NODE_ENV=development webpack --progress -p --config react/client.dev.js",
     "build:server": "rimraf react/buildServer && cross-env NODE_ENV=production webpack --progress -p --config react/server.prod.js",
     "clean": "rimraf react/buildClient react/buildServer"
   },

--- a/react/client.dev.js
+++ b/react/client.dev.js
@@ -1,0 +1,88 @@
+const path = require('path');
+const webpack = require('webpack');
+const WriteFilePlugin = require('write-file-webpack-plugin');
+const AutoDllPlugin = require('autodll-webpack-plugin');
+const ExtractCssChunks = require('extract-css-chunks-webpack-plugin');
+
+module.exports = {
+	name: 'client',
+	target: 'web',
+	// devtool: 'source-map',
+	devtool: 'eval',
+	entry: [
+		'babel-polyfill',
+		'fetch-everywhere',
+		// 'webpack-hot-middleware/client?path=/__webpack_hmr&timeout=20000&reload=false&quiet=false&noInfo=false',
+		// 'react-hot-loader/patch',
+		path.resolve(__dirname, './src/index.js')
+	],
+	output: {
+		filename: '[name].js',
+		chunkFilename: '[name].js',
+		path: path.resolve(__dirname, './buildClient'),
+		publicPath: '/static/'
+	},
+	module: {
+		rules: [
+			{
+				test: /\.js$/,
+				exclude: /node_modules/,
+				use: 'babel-loader'
+			},
+			{
+				test: /\.css$/,
+				use: ExtractCssChunks.extract({
+					use: {
+						loader: 'css-loader',
+						options: {
+							modules: true,
+							localIdentName: '[name]__[local]--[hash:base64:5]'
+						}
+					}
+				})
+			}
+		]
+	},
+	resolve: {
+		extensions: ['.js', '.css']
+	},
+	plugins: [
+		new WriteFilePlugin(), // used so you can see what chunks are produced in dev
+		new ExtractCssChunks(),
+		new webpack.optimize.CommonsChunkPlugin({
+			names: ['bootstrap'], // needed to put webpack bootstrap code before chunks
+			filename: '[name].js',
+			minChunks: Infinity
+		}),
+
+		new webpack.HotModuleReplacementPlugin(),
+		new webpack.NoEmitOnErrorsPlugin(),
+		new webpack.DefinePlugin({
+			'process.env': {
+				NODE_ENV: JSON.stringify('development')
+			}
+		}),
+		new AutoDllPlugin({
+			context: path.join(__dirname, '..'),
+			filename: '[name].js',
+			entry: {
+				vendor: [
+					'react',
+					'react-dom',
+					'react-redux',
+					'redux',
+					'history/createBrowserHistory',
+					'transition-group',
+					'redux-first-router',
+					'redux-first-router-link',
+					'fetch-everywhere',
+					'babel-polyfill',
+					'redux-devtools-extension/logOnlyInProduction'
+				]
+			}
+		})
+	],
+	externals : {
+		config : JSON.stringify(require('./src/config.json'))
+	}
+};

--- a/react/src/components/Page.js
+++ b/react/src/components/Page.js
@@ -3,26 +3,21 @@ import {connect} from 'react-redux';
 import Typography from 'material-ui/Typography';
 import moment from 'moment';
 
-const Post = ({post}) =>
+const Page = ({post}) =>
 	<div>
 		<Typography type='title' gutterBottom>
 			{post.title}
 		</Typography>
 		<Typography type='subheading' gutterBottom>
-			{post.description}<br/>
-			{moment(post.createdAt).format('MM/DD/YY')}
+			{post.description}
 		</Typography>
 		<Typography type='body1' gutterBottom>
 			{post.content}
 		</Typography>
-
-		<pre>
-			{JSON.stringify(post, null, 4)}
-		</pre>
 	</div>;
 
 const mapState = state => {
 	return state.post || {};
 };
 
-export default connect(mapState)(Post);
+export default connect(mapState)(Page);

--- a/react/src/components/Switcher.js
+++ b/react/src/components/Switcher.js
@@ -5,14 +5,16 @@ import UniversalComponent from './UniversalComponent';
 
 import styles from '../css/Switcher';
 
-const Switcher = ({page, direction}) =>
-	<TransitionGroup
+const Switcher = ({page, direction}) =>{
+	return <TransitionGroup
 		className = {`${styles.switcher} ${direction}`}
 	>
 		<Transition key={page}>
 			<UniversalComponent page={page} />
 		</Transition>
 	</TransitionGroup>;
+};
+
 
 const mapState = ({page, direction, ...state}) => ({
 	page,

--- a/react/src/components/UniversalComponent.js
+++ b/react/src/components/UniversalComponent.js
@@ -14,11 +14,7 @@ export default ({page, isLoading}) => {
 };
 
 const components = {
-	About : universal(() => import('./About'), {
-		minDelay : 0,
-		loading
-	}),
-	Contact : universal(() => import('./Contact'), {
+	Page : universal(() => import('./Page'), {
 		minDelay : 0,
 		loading
 	}),

--- a/react/src/reducers/page.js
+++ b/react/src/reducers/page.js
@@ -1,13 +1,15 @@
 import {NOT_FOUND} from 'redux-first-router';
 
 export default (state = 'PORTFOLIO', action = {}) => {
+	console.log(action.type);
+	console.log(components[action.type]);
 	return components[action.type] || state;
 };
 
 const components = {
-	ABOUT: 'About',
-	PORTFOLIO: 'Portfolio',
-	CONTACT : 'Contact',
-	POST: 'Post',
-	[NOT_FOUND]: 'NotFound'
+	ABOUT_FETCHED   : 'Page',
+	PORTFOLIO       : 'Portfolio',
+	CONTACT_FETCHED : 'Page',
+	POST_FETCHED    : 'Post',
+	[NOT_FOUND]     : 'NotFound'
 };

--- a/react/src/reducers/post.js
+++ b/react/src/reducers/post.js
@@ -1,5 +1,7 @@
 export default (state = {}, action = {}) => {
-	if (action.type === 'POST_FETCHED'){
+	if (action.type === 'POST_FETCHED'
+	|| action.type === 'ABOUT_FETCHED'
+	|| action.type === 'CONTACT_FETCHED'){
 		const {post} = action.payload;
 		return {...state, post};
 	}

--- a/react/src/routesMap.js
+++ b/react/src/routesMap.js
@@ -24,7 +24,37 @@ export default {
 			dispatch({type : 'POST_FETCHED', payload : {post}});
 		}
 	},
-	ABOUT: '/about',
-	PORTFOLIO : '/',
-	CONTACT : '/contact'
+	ABOUT: {
+		path : '/about',
+		thunk : async(dispatch, getState) => {
+			const {
+				jwToken
+			} = getState();
+
+			const post = await fetchData('/api/posts/about');
+
+			if(!post) {
+				return dispatch({type: NOT_FOUND});
+			}
+
+			dispatch({type : 'ABOUT_FETCHED', payload : {post}});
+		}
+	},
+	CONTACT: {
+		path : '/contact',
+		thunk : async(dispatch, getState) => {
+			const {
+				jwToken
+			} = getState();
+
+			const post = await fetchData('/api/posts/contact');
+
+			if(!post) {
+				return dispatch({type: NOT_FOUND});
+			}
+
+			dispatch({type : 'CONTACT_FETCHED', payload : {post}});
+		}
+	},
+	PORTFOLIO : '/'
 };

--- a/react/src/utils.js
+++ b/react/src/utils.js
@@ -3,13 +3,17 @@ import config from './config.json';
 
 export const isServer = typeof window === 'undefined';
 
-export const fetchData = async (path, token) =>
-fetch(`${config.apiURL}${path}`, {
-	headers: {
-		Accept: 'application/json',
-		Authorization: token
+export const fetchData = async (path, token) => {
+	let options = {
+		headers : {
+			Accept : 'application/json'
+		}
+	};
+	if(token){
+		options.headers.Authorization = token;
 	}
-}).then(data => data.json());
+	return fetch(`${config.apiURL}${path}`, options).then(data => data.json());
+};
 
 /**
  * TODO: Implement this

--- a/routes/users.js
+++ b/routes/users.js
@@ -162,7 +162,7 @@ module.exports = (server, prefix) => {
 			return res.json(validation);
 		}
 
-		return Morty.services.user.findById(req.params.id).then((result) => {
+		return Morty.services.user.findById({id : req.params.id}).then((result) => {
 			if(result){
 				// Ensure the user can update this user
 				// Must be the Owner or an Admin

--- a/services/post.js
+++ b/services/post.js
@@ -18,13 +18,20 @@ exports.create = (doc) => {
 };
 
 /**
- * Find a Post by id
+ * Find a Post by id or slug
  * @param  {Object} params Find parameters
  * @return {Promise}
  */
-exports.findById = (params) => {
+exports.findOne = (params) => {
 	return new Promise((resolve, reject) => {
-		let search = Morty.models.post.findById(params.id);
+		let query = {};
+		if('id' in params){
+			query._id = params.id;
+		}
+		if('slug' in params){
+			query.slug = params.slug;
+		}
+		let search = Morty.models.post.findOne(query);
 
 		if(params.fields){
 			let fields = '';


### PR DESCRIPTION
* Added optional slugs to posts.  Posts with slugs can be looked up by
their slug instead of their id if desired.
* Tabs in react project are now using slugs to dynamically load the
about and contact pages from backing posts.
* Added a utility library.
* Fixed various bugs found while testing the API.
* Added some basic support for a dev client for the front end.  Server
side rendering still only has prod, so it’s not worth using right now.